### PR TITLE
Feature/pose comparison operator

### DIFF
--- a/include/kindr/common/common.hpp
+++ b/include/kindr/common/common.hpp
@@ -129,6 +129,18 @@ class MultiplicationTraits {
 //  inline static Left_ mult(const Left_& lhs, const Right_& rhs);
 };
 
+/*! \brief Comparison traits for comparing different rotations
+ *  \class ComparisonTraits
+ *  (only for advanced users)
+ */
+template<typename Left_, typename Right_>
+class ComparisonTraits {
+ public:
+  inline static bool isEqual(const Left_& left, const Right_& right) {
+    return left.toImplementation() == Left_(right).toImplementation();
+  }
+};
+
 
 /*! \class get_scalar
  *  \brief Gets the primitive of the vector.

--- a/include/kindr/common/common.hpp
+++ b/include/kindr/common/common.hpp
@@ -129,16 +129,14 @@ class MultiplicationTraits {
 //  inline static Left_ mult(const Left_& lhs, const Right_& rhs);
 };
 
-/*! \brief Comparison traits for comparing different rotations
+/*! \brief Comparison traits
  *  \class ComparisonTraits
  *  (only for advanced users)
  */
 template<typename Left_, typename Right_>
 class ComparisonTraits {
  public:
-  inline static bool isEqual(const Left_& left, const Right_& right) {
-    return left.toImplementation() == Left_(right).toImplementation();
-  }
+//  inline static bool isEqual(const Left_& left, const Right_& right);
 };
 
 

--- a/include/kindr/poses/Pose.hpp
+++ b/include/kindr/poses/Pose.hpp
@@ -84,6 +84,17 @@ class MultiplicationTraits<PoseBase<Left_>, PoseBase<Right_> > {
 //  }
 //};
 
+/*! \brief Compare two poses.
+ */
+template<typename Left_, typename Right_>
+class ComparisonTraits<PoseBase<Left_>, PoseBase<Right_>>{
+ public:
+  inline static bool isEqual(const PoseBase<Left_>& lhs, const PoseBase<Right_>& rhs) {
+    return lhs.derived().getPosition() == rhs.derived().getPosition() &&
+           lhs.derived().getRotation() == rhs.derived().getRotation();
+  }
+};
+
 
 } // namespace internal
 } // namespace kindr

--- a/include/kindr/poses/PoseBase.hpp
+++ b/include/kindr/poses/PoseBase.hpp
@@ -139,6 +139,14 @@ class PoseBase {
     return internal::MultiplicationTraits<PoseBase<Derived_>,PoseBase<OtherDerived_>>::mult(this->derived(), other.derived()); // todo: 1. ok? 2. may be optimized
   }
 
+  /*! \brief Compares two poses.
+   *  \returns true if the poses are exactly equal
+   */
+  template<typename OtherDerived_>
+  bool operator ==(const PoseBase<OtherDerived_>& other) const {
+    return internal::ComparisonTraits<PoseBase<Derived_>,PoseBase<OtherDerived_>>::isEqual(*this, other);
+  }
+
   /*! \brief Sets the pose to identity
    *  \returns reference
    */

--- a/include/kindr/rotations/AngleAxis.hpp
+++ b/include/kindr/rotations/AngleAxis.hpp
@@ -429,14 +429,14 @@ class ConversionTraits<AngleAxis<DestPrimType_>, EulerAnglesZyx<SourcePrimType_>
  * Comparison Traits
  * ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- */
 template<typename PrimType_>
-class ComparisonTraits<AngleAxis<PrimType_>, AngleAxis<PrimType_>> {
+class ComparisonTraits<RotationBase<AngleAxis<PrimType_>>, RotationBase<AngleAxis<PrimType_>>> {
  public:
-  inline static bool isEqual(const AngleAxis<PrimType_>& a, const AngleAxis<PrimType_>& b){
+  inline static bool isEqual(const RotationBase<AngleAxis<PrimType_>>& a, const RotationBase<AngleAxis<PrimType_>>& b){
     const PrimType_ tolPercent = 0.01;
-    return compareRelative(a.angle(), b.angle(), tolPercent) &&
-        compareRelative(a.axis().x(), b.axis().x(), tolPercent) &&
-        compareRelative(a.axis().y(), b.axis().y(), tolPercent) &&
-        compareRelative(a.axis().z(), b.axis().z(), tolPercent);
+    return compareRelative(a.derived().angle(), b.derived().angle(), tolPercent) &&
+        compareRelative(a.derived().axis().x(), b.derived().axis().x(), tolPercent) &&
+        compareRelative(a.derived().axis().y(), b.derived().axis().y(), tolPercent) &&
+        compareRelative(a.derived().axis().z(), b.derived().axis().z(), tolPercent);
   }
 };
 

--- a/include/kindr/rotations/Rotation.hpp
+++ b/include/kindr/rotations/Rotation.hpp
@@ -204,7 +204,7 @@ class SetFromVectorsTraits<RotationBase<Rotation_>> {
  * Disparity Angle Traits
  * ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- */
 
-/*! \brief Compares two rotations.
+/*! \brief Compute the disparity angle between two rotations.
  *
  */
 template<typename Left_, typename Right_>

--- a/include/kindr/rotations/Rotation.hpp
+++ b/include/kindr/rotations/Rotation.hpp
@@ -129,16 +129,8 @@ class RotationTraits<RotationBase<Rotation_>> {
 template<typename Left_, typename Right_>
 class ComparisonTraits<RotationBase<Left_>, RotationBase<Right_>> {
  public:
-  /*! \brief Gets the disparity angle between two rotations.
-   *
-   *  The disparity angle is defined as the angle of the angle-axis representation of the concatenation of
-   *  the first rotation and the inverse of the second rotation. If the disparity angle is zero,
-   *  the rotations are equal.
-   *  \returns disparity angle in [-pi,pi) @todo: is this range correct?
-   */
-  inline static typename Left_::Scalar get_disparity_angle(const RotationBase<Left_>& left, const RotationBase<Right_>& right) {
-    typedef typename Left_::Scalar Scalar;
-    return std::abs(floatingPointModulo(AngleAxis<Scalar>(left.derived()*right.derived().inverted()).angle() + Scalar(M_PI), Scalar(2.0*M_PI))-M_PI);
+  inline static bool isEqual(const RotationBase<Left_>& left, const RotationBase<Right_>& right) {
+    return left.derived().toImplementation() == RotationBase<Left_>(right).derived().toImplementation();
   }
 };
 
@@ -205,6 +197,29 @@ class SetFromVectorsTraits<RotationBase<Rotation_>> {
 //      const Eigen::Matrix<PrimType_, 3, 1> axis = (v1.cross(v2)).normalized();
 //      rot = AngleAxis<PrimType_>(angle, axis);
 //    }
+  }
+};
+
+/* -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ * Disparity Angle Traits
+ * ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- */
+
+/*! \brief Compares two rotations.
+ *
+ */
+template<typename Left_, typename Right_>
+class DisparityAngleTraits<RotationBase<Left_>, RotationBase<Right_>> {
+ public:
+  /*! \brief Gets the disparity angle between two rotations.
+   *
+   *  The disparity angle is defined as the angle of the angle-axis representation of the concatenation of
+   *  the first rotation and the inverse of the second rotation. If the disparity angle is zero,
+   *  the rotations are equal.
+   *  \returns disparity angle in [-pi,pi) @todo: is this range correct?
+   */
+  inline static typename Left_::Scalar compute(const RotationBase<Left_>& left, const RotationBase<Right_>& right) {
+    typedef typename Left_::Scalar Scalar;
+    return std::abs(floatingPointModulo(AngleAxis<Scalar>(left.derived()*right.derived().inverted()).angle() + Scalar(M_PI), Scalar(2.0*M_PI))-M_PI);
   }
 };
 

--- a/include/kindr/rotations/RotationBase.hpp
+++ b/include/kindr/rotations/RotationBase.hpp
@@ -68,18 +68,6 @@ class ConversionTraits {
   // inline static Dest_ convert(const Source_& );
 };
 
-/*! \brief Comparison traits for comparing different rotations
- *  \class ComparisonTraits
- *  (only for advanced users)
- */
-template<typename Left_, typename Right_>
-class ComparisonTraits {
- public:
-  inline static bool isEqual(const Left_& left, const Right_& right) {
-    return left.toImplementation() == Left_(right).toImplementation();
-  }
-};
-
 
 
 /*! \brief Rotation traits for rotating vectors and matrices

--- a/include/kindr/rotations/RotationBase.hpp
+++ b/include/kindr/rotations/RotationBase.hpp
@@ -111,6 +111,16 @@ class SetFromVectorsTraits {
  public:
 };
 
+/*! \brief Disparity angle traits for computing the disparity angle between two rotations.
+ *  \class DisparityAngleTraits
+ *  (only for advanced users)
+ */
+template<typename Left_, typename Right_>
+class DisparityAngleTraits {
+ public:
+  // inline static typename internal::get_scalar<Derived_>::Scalar compute(const Left_& left, const Right_& right);
+};
+
 /*! \brief Fixes the rotation to get rid of numerical errors (e.g. normalize quaternion).
  *  \class RotationTraits
  *  (only for advanced users)
@@ -246,7 +256,7 @@ class RotationBase {
    */
   template<typename OtherDerived_>
   bool operator ==(const RotationBase<OtherDerived_>& other) const { // todo: may be optimized
-    return internal::ComparisonTraits<Derived_,OtherDerived_>::isEqual(this->derived().getUnique(), other.derived().getUnique()); // the type conversion must already take place here to ensure the specialised isequal function is called more often
+    return internal::ComparisonTraits<RotationBase<Derived_>, RotationBase<OtherDerived_>>::isEqual(this->derived().getUnique(), other.derived().getUnique()); // the type conversion must already take place here to ensure the specialised isequal function is called more often
   }
 
   /*! \brief Gets the disparity angle between two rotations for comparison.
@@ -259,7 +269,7 @@ class RotationBase {
    */
   template<typename OtherDerived_>
   typename internal::get_scalar<Derived_>::Scalar getDisparityAngle(const RotationBase<OtherDerived_>& other) const {
-    return internal::ComparisonTraits<RotationBase<Derived_>, RotationBase<OtherDerived_>>::get_disparity_angle(this->derived(), other.derived());
+    return internal::DisparityAngleTraits<RotationBase<Derived_>, RotationBase<OtherDerived_>>::compute(this->derived(), other.derived());
   }
 
   /*! \brief Compares two rotations with a tolerance.

--- a/include/kindr/rotations/RotationQuaternion.hpp
+++ b/include/kindr/rotations/RotationQuaternion.hpp
@@ -586,13 +586,13 @@ class ConversionTraits<RotationQuaternion<DestPrimType_>, EulerAnglesZyx<SourceP
  * Comparison Traits
  * ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- */
 template<typename PrimType_>
-class ComparisonTraits<RotationQuaternion<PrimType_>, RotationQuaternion<PrimType_>> {
+class ComparisonTraits<RotationBase<RotationQuaternion<PrimType_>>, RotationBase<RotationQuaternion<PrimType_>>> {
  public:
-   inline static bool isEqual(const RotationQuaternion<PrimType_>& a, const RotationQuaternion<PrimType_>& b){
-     return a.toImplementation().w() ==  b.toImplementation().w() &&
-            a.toImplementation().x() ==  b.toImplementation().x() &&
-            a.toImplementation().y() ==  b.toImplementation().y() &&
-            a.toImplementation().z() ==  b.toImplementation().z();
+   inline static bool isEqual(const RotationBase<RotationQuaternion<PrimType_>>& a, const RotationBase<RotationQuaternion<PrimType_>>& b){
+     return a.derived().toImplementation().w() ==  b.derived().toImplementation().w() &&
+            a.derived().toImplementation().x() ==  b.derived().toImplementation().x() &&
+            a.derived().toImplementation().y() ==  b.derived().toImplementation().y() &&
+            a.derived().toImplementation().z() ==  b.derived().toImplementation().z();
    }
 };
 

--- a/test/poses/HomogeneousTransformationTest.cpp
+++ b/test/poses/HomogeneousTransformationTest.cpp
@@ -90,6 +90,26 @@ TYPED_TEST(HomogeneousTransformationTest, testSetIdentity)
 }
 
 
+TYPED_TEST(HomogeneousTransformationTest, testComparisonEqual)
+{
+  typedef typename TestFixture::Pose Pose;
+  typedef typename TestFixture::Position Position;
+  typedef typename TestFixture::Rotation Rotation;
+  typedef typename TestFixture::Scalar Scalar;
+  Position positionAToBInA(1.0,2.0,3.0);
+  Position positionAToCInA(1.0,2.0,4.0);
+  Rotation rotationBToA(kindr::EulerAnglesZyx<Scalar>(0.5, -0.9, 1.2));
+  Rotation rotationCToA(kindr::EulerAnglesZyx<Scalar>(0.5, -0.9, 1.2));
+  Pose poseBToA(positionAToBInA, rotationBToA);
+  Pose poseBToA2(positionAToBInA, rotationBToA);
+  Pose poseCToA(positionAToCInA, rotationCToA);
+
+  // Check equality comparison
+  ASSERT_TRUE(poseBToA == poseBToA2);
+  ASSERT_FALSE(poseBToA == poseCToA);
+}
+
+
 TYPED_TEST(HomogeneousTransformationTest, testTransform)
 {
   typedef typename TestFixture::Pose Pose;


### PR DESCRIPTION
Added operator== to compare Poses.

* Moved ComparisonTraits to common.hpp (as they are now used by rotations AND poses)
* Implemented ComparisonTraits for poses.
* Moved get_disparity_angle to separate traits, as the implementation cannot be in the same specialization as isEqual.
* Added gtest for pose comparison operator. 

All gtests pass.