### PR TITLE
Add static keyword to RotationBase::exponentialMap(vector)

### DIFF
--- a/include/kindr/rotations/RotationBase.hpp
+++ b/include/kindr/rotations/RotationBase.hpp
@@ -318,7 +318,7 @@ class RotationBase {
    * \param vector  Eigen::Matrix<Scalar 3, 1>
    * \return  reference to modified rotation
    */
-  Derived_ exponentialMap(const typename internal::get_matrix3X<Derived_>::template Matrix3X<1>& vector)  {
+  static Derived_ exponentialMap(const typename internal::get_matrix3X<Derived_>::template Matrix3X<1>& vector)  {
    return internal::MapTraits<RotationBase<Derived_>>::set_exponential_map(vector);
   }
 


### PR DESCRIPTION
The method does not modify the instance in any way, but returns a new instance of the same type. So it can be static. Note that the doxygen documentation and the function name `MapTraits<T>::set_exponential_map()` is misleading. Or is it considered a bug that the value of `*this` is actually not touched?

Without this patch clang 3.8 emits a warning due to use of uninitialized variables [when used like](https://bitbucket.org/bloesch/lightweight_filtering/src/bb2ad1291599b0bb38f6c98551b95aa3d6524850/include/lightweight_filtering/State.hpp?fileviewer=file-view-default#State.hpp-316):

```cpp
{
  kindr::RotationQuaternionPD q = q.exponentialMap(theta);
  // ==> error: variable 'q' is uninitialized when used within its own initialization [-Werror,-Wuninitialized]
}
```

which seems reasonable. Ideally those lines would be replaced by something like

```cpp
{
  auto q = kindr::RotationQuaternionPD::exponentialMap(theta);
  // ...
}
```

Adding the `static` modifier fixes the warning/error while retaining full backwards compatibility for users.