### PR TITLE
added if-guard around the cmake unistall target to avoid collision wi…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,5 +135,7 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
     IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
+if (NOT TARGET uninstall)
+  add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()


### PR DESCRIPTION
…th uninstall targets from other packages --> used when adding kindr to other projects via `add_subdirectory()`.