### PR TITLE
Fix/rotation unit tests

### DIFF
--- a/include/kindr/rotations/RotationBase.hpp
+++ b/include/kindr/rotations/RotationBase.hpp
@@ -162,6 +162,10 @@ class RotationBase {
    */
   RotationBase() = default;
 
+  RotationBase(const RotationBase& other) {
+    derived() = other.derived();
+  }
+
   /*! \brief Constructor from derived rotation.
    *  This constructor has been deleted because the abstract class does not contain any data.
    */

--- a/test/rotations/AngleAxisTest.cpp
+++ b/test/rotations/AngleAxisTest.cpp
@@ -369,19 +369,13 @@ TYPED_TEST(AngleAxisSingleTest, testConcatenation){
   // Check concatenation of 4 quarters
   rotAngleAxis = this->rotAngleAxisQuarterX*this->rotAngleAxisQuarterX*this->rotAngleAxisQuarterX*this->rotAngleAxisQuarterX;
   ASSERT_NEAR(rotAngleAxis.getUnique().angle(), this->rotAngleAxisIdentity.getUnique().angle(),1e-6);
-  ASSERT_NEAR(rotAngleAxis.getUnique().axis().x(), this->rotAngleAxisIdentity.getUnique().axis().x(),1e-6);
-  ASSERT_NEAR(rotAngleAxis.getUnique().axis().y(), this->rotAngleAxisIdentity.getUnique().axis().y(),1e-6);
-  ASSERT_NEAR(rotAngleAxis.getUnique().axis().z(), this->rotAngleAxisIdentity.getUnique().axis().z(),1e-6);
+  // Axis is undefined if rotation near 0 -> no test necessary
   rotAngleAxis = this->rotAngleAxisQuarterY*this->rotAngleAxisQuarterY*this->rotAngleAxisQuarterY*this->rotAngleAxisQuarterY;
   ASSERT_NEAR(rotAngleAxis.getUnique().angle(), this->rotAngleAxisIdentity.getUnique().angle(),1e-6);
-  ASSERT_NEAR(rotAngleAxis.getUnique().axis().x(), this->rotAngleAxisIdentity.getUnique().axis().x(),1e-6);
-  ASSERT_NEAR(rotAngleAxis.getUnique().axis().y(), this->rotAngleAxisIdentity.getUnique().axis().y(),1e-6);
-  ASSERT_NEAR(rotAngleAxis.getUnique().axis().z(), this->rotAngleAxisIdentity.getUnique().axis().z(),1e-6);
+// Axis is undefined if rotation near 0 -> no test necessary
   rotAngleAxis = this->rotAngleAxisQuarterZ*this->rotAngleAxisQuarterZ*this->rotAngleAxisQuarterZ*this->rotAngleAxisQuarterZ;
   ASSERT_NEAR(rotAngleAxis.getUnique().angle(), this->rotAngleAxisIdentity.getUnique().angle(),1e-6);
-  ASSERT_NEAR(rotAngleAxis.getUnique().axis().x(), this->rotAngleAxisIdentity.getUnique().axis().x(),1e-6);
-  ASSERT_NEAR(rotAngleAxis.getUnique().axis().y(), this->rotAngleAxisIdentity.getUnique().axis().y(),1e-6);
-  ASSERT_NEAR(rotAngleAxis.getUnique().axis().z(), this->rotAngleAxisIdentity.getUnique().axis().z(),1e-6);
+// Axis is undefined if rotation near 0 -> no test necessary
 
   // Check concatenation of 3 different quarters
   rotAngleAxis = this->rotAngleAxisQuarterX.inverted()*this->rotAngleAxisQuarterY*this->rotAngleAxisQuarterX;


### PR DESCRIPTION
Fixes failing unit tests.

Issues were
- implicitly-declared constructor in RotationBase, which doesn't set data in Implementation, leading to an incorrect comparison in RotationBase::isEqual

- AngleAxis comparison of four quarter-rotations to default angle-axis fails due to numerical error. If rotation angle is near 0, the rotation axis is not defined/might be mirrored. The corresponding tests on the axis were removed